### PR TITLE
Update flutter_sticky_headers

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   collection: ^1.17.2
-  flutter_sticky_header: ^0.6.5
+  flutter_sticky_header: ^0.7.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Update flutter_sticky_headers to 0.7.0 to fix issue on Flutter 3.29.3 (iOS version)